### PR TITLE
Slightly better token name

### DIFF
--- a/authenticator.js
+++ b/authenticator.js
@@ -13,7 +13,7 @@ function AuthenticateGithub(opts) {
     githubPathPrefix: '/api/v3',
     githubOrg: config.githubOrg,
     // label the token that we generate.
-    note: 'npm on premises solution',
+    note: 'npm On-Site authentication',
     noteUrl: 'https://www.npmjs.org'
   }, opts);
 }

--- a/test/authenticate-test.js
+++ b/test/authenticate-test.js
@@ -28,7 +28,7 @@ Lab.experiment('getAuthorizationToken', function() {
       })
       .post('/api/v3/authorizations', {
         scopes: ["user","public_repo","repo","repo:status","gist"],
-        note: 'npm on premises solution (0)',
+        note: 'npm On-Site authentication (0)',
         note_url: 'https://www.npmjs.org'
       })
       .reply(200, fs.readFileSync('./test/fixtures/authenticate-success.json'));
@@ -58,7 +58,7 @@ Lab.experiment('getAuthorizationToken', function() {
       })
       .post('/api/v3/authorizations', {
         scopes: ["user","public_repo","repo","repo:status","gist"],
-        note: 'npm on premises solution (0)',
+        note: 'npm On-Site authentication (0)',
         note_url: 'https://www.npmjs.org'
       })
       .reply(200, fs.readFileSync('./test/fixtures/authenticate-success.json'));
@@ -129,7 +129,7 @@ Lab.experiment('getAuthorizationToken', function() {
       })
       .post('/api/v3/authorizations', {
         scopes: ["user","public_repo","repo","repo:status","gist"],
-        note: 'npm on premises solution (0)',
+        note: 'npm On-Site authentication (0)',
         note_url: 'https://www.npmjs.org'
       })
       .reply(200, fs.readFileSync('./test/fixtures/authenticate-success.json'))
@@ -163,7 +163,7 @@ Lab.experiment('getAuthorizationToken', function() {
       })
       .post('/api/v3/authorizations', {
         scopes: ["user","public_repo","repo","repo:status","gist"],
-        note: 'npm on premises solution (0)',
+        note: 'npm On-Site authentication (0)',
         note_url: 'https://www.npmjs.org'
       })
       .reply(200, fs.readFileSync('./test/fixtures/authenticate-success.json'))
@@ -198,7 +198,7 @@ Lab.experiment('authenticate', function() {
       })
       .post('/api/v3/authorizations', {
         scopes: ["user","public_repo","repo","repo:status","gist"],
-        note: 'npm on premises solution (0)',
+        note: 'npm On-Site authentication (0)',
         note_url: 'https://www.npmjs.org'
       })
       .reply(200, fs.readFileSync('./test/fixtures/authenticate-success.json'));


### PR DESCRIPTION
Just change "npm on premises solution" -> "npm On-Site authentication". Using the On-Site name looks more official to me.

Compare:
<img width="733" alt="screen shot 2015-12-08 at 4 53 51 pm" src="https://cloud.githubusercontent.com/assets/1929625/11669796/8950c33e-9dcc-11e5-9b8e-6a3ef8cf3ccf.png">
