### PR TITLE
Update registry used for @npm scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "0.12"
   - "0.10"
-  - iojs
+  - "4"
+  - "node"
 services:
   - redis-server
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ services:
 before_install:
   - if [[ `node --version` =~ "v0.10" ]]; then npm install -g npm@latest; fi
   - npm config set spin false
-  - printf "@npm:registry=https://enterprise.npmjs.com\n" >> ~/.npmrc
+  - printf "@npm:registry=https://registry.internal.npmjs.com/\n//registry.internal.npmjs.com/:_authToken=${NPM_TOKEN}\n" >> ~/.npmrc


### PR DESCRIPTION
Use `registry.internal.npmjs.com` instead of `enterprise.npmjs.com` for CI builds

Also update Node versions to test against