### PR TITLE
feat: "npm On-Site authentication" → "npm Enterprise login"

### DIFF
--- a/authenticator.js
+++ b/authenticator.js
@@ -13,7 +13,7 @@ function AuthenticateGithub(opts) {
     githubPathPrefix: '/api/v3',
     githubOrg: config.githubOrg,
     // label the token that we generate.
-    note: 'npm On-Site authentication',
+    note: 'npm Enterprise login',
     noteUrl: 'https://www.npmjs.org'
   }, opts);
 }

--- a/test/authenticate-test.js
+++ b/test/authenticate-test.js
@@ -28,7 +28,7 @@ Lab.experiment('getAuthorizationToken', function() {
       })
       .post('/api/v3/authorizations', {
         scopes: ["user","public_repo","repo","repo:status","gist"],
-        note: 'npm On-Site authentication (0)',
+        note: 'npm Enterprise login (0)',
         note_url: 'https://www.npmjs.org'
       })
       .reply(200, fs.readFileSync('./test/fixtures/authenticate-success.json'));
@@ -58,7 +58,7 @@ Lab.experiment('getAuthorizationToken', function() {
       })
       .post('/api/v3/authorizations', {
         scopes: ["user","public_repo","repo","repo:status","gist"],
-        note: 'npm On-Site authentication (0)',
+        note: 'npm Enterprise login (0)',
         note_url: 'https://www.npmjs.org'
       })
       .reply(200, fs.readFileSync('./test/fixtures/authenticate-success.json'));
@@ -129,7 +129,7 @@ Lab.experiment('getAuthorizationToken', function() {
       })
       .post('/api/v3/authorizations', {
         scopes: ["user","public_repo","repo","repo:status","gist"],
-        note: 'npm On-Site authentication (0)',
+        note: 'npm Enterprise login (0)',
         note_url: 'https://www.npmjs.org'
       })
       .reply(200, fs.readFileSync('./test/fixtures/authenticate-success.json'))
@@ -163,7 +163,7 @@ Lab.experiment('getAuthorizationToken', function() {
       })
       .post('/api/v3/authorizations', {
         scopes: ["user","public_repo","repo","repo:status","gist"],
-        note: 'npm On-Site authentication (0)',
+        note: 'npm Enterprise login (0)',
         note_url: 'https://www.npmjs.org'
       })
       .reply(200, fs.readFileSync('./test/fixtures/authenticate-success.json'))
@@ -198,7 +198,7 @@ Lab.experiment('authenticate', function() {
       })
       .post('/api/v3/authorizations', {
         scopes: ["user","public_repo","repo","repo:status","gist"],
-        note: 'npm On-Site authentication (0)',
+        note: 'npm Enterprise login (0)',
         note_url: 'https://www.npmjs.org'
       })
       .reply(200, fs.readFileSync('./test/fixtures/authenticate-success.json'));


### PR DESCRIPTION
Rebranding for fun and profit.

Fixes #31.

Does **not** change the package or repo name.