### PR TITLE
chore(package): add standard-version as npm run release

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/npm/npmo-auth-github.git"
   },
   "scripts": {
-    "test": "lab -v -c --timeout 1000 test/ --ignore '$$bole'"
+    "test": "lab -v -c --timeout 1000 test/ --ignore '$$bole'",
+    "release": "standard-version"
   },
   "dependencies": {
     "@npm/enterprise-configurator": "~0.1.8",
@@ -22,6 +23,7 @@
   "devDependencies": {
     "code": "~1.3.0",
     "lab": "~5.2.1",
-    "nock": "^0.48.1"
+    "nock": "^0.48.1",
+    "standard-version": "^2.1.2"
   }
 }


### PR DESCRIPTION
A better alternative to `npm version`.